### PR TITLE
Fix/ai service provider pattern

### DIFF
--- a/ai-service/cmd/main.go
+++ b/ai-service/cmd/main.go
@@ -1,48 +1,53 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"ai-service/internal/llm"
 
 	"github.com/joho/godotenv"
 )
 
+const maxRetries = 3
+
 func main() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Println("Aviso: não foi possível carregar .env")
+	if err := godotenv.Load(); err != nil {
+		log.Println("aviso: .env nao encontrado; usando variaveis do sistema")
 	}
-
-	apiKey := os.Getenv("OPENROUTER_API_KEY")
-	if apiKey == "" {
-		log.Fatal("OPENROUTER_API_KEY não definida")
-	}
-
-	fmt.Println("Chave carregada com sucesso!")
 
 	text := getSampleText()
+	ctx := context.Background()
 
-	summary, err := llm.Summarize(text)
+	var (
+		summary string
+		err     error
+	)
+	for i := 1; i <= maxRetries; i++ {
+		summary, err = llm.Summarize(ctx, text)
+		if err == nil {
+			break
+		}
+		log.Printf("tentativa %d/%d falhou: %v", i, maxRetries, err)
+		if i < maxRetries {
+			time.Sleep(time.Duration(i) * 2 * time.Second)
+		}
+	}
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("erro apos %d tentativas: %v", maxRetries, err)
 	}
 
-	fmt.Println("\n📄 TEXTO ORIGINAL:")
-	fmt.Println(text)
-
-	fmt.Println("\n🧠 RESUMO GERADO:")
+	fmt.Println("\nRESUMO GERADO:")
 	fmt.Println(summary)
 }
 
 func getSampleText() string {
-	return `O governo do estado anunciou nesta terça-feira um novo pacote de medidas voltadas para a melhoria da infraestrutura urbana. 
-O plano inclui investimentos em mobilidade, saneamento básico e modernização de serviços públicos digitais. 
-
-Segundo o secretário de planejamento, as ações fazem parte de uma estratégia de longo prazo que busca aumentar a eficiência dos serviços prestados à população. 
-Especialistas apontam que, embora as medidas sejam positivas, será necessário garantir a execução adequada dos projetos para que os resultados sejam efetivos.
-
-A previsão é de que as primeiras obras sejam iniciadas ainda no próximo semestre.`
+	if v := os.Getenv("INPUT_TEXT"); v != "" {
+		return v
+	}
+	return `O governo do estado anunciou nesta terca-feira um novo pacote de medidas voltadas para a melhoria da infraestrutura urbana.
+O plano inclui investimentos em mobilidade, saneamento basico e modernizacao de servicos publicos digitais.`
 }

--- a/ai-service/internal/llm/llm_service.go
+++ b/ai-service/internal/llm/llm_service.go
@@ -2,11 +2,13 @@ package llm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"time"
 )
 
 var APIURL = "https://openrouter.ai/api/v1/chat/completions"
@@ -14,6 +16,7 @@ var APIURL = "https://openrouter.ai/api/v1/chat/completions"
 type HFRequest struct {
 	Model    string      `json:"model"`
 	Messages []HFMessage `json:"messages"`
+	Stream   bool        `json:"stream"`
 }
 
 type HFMessage struct {
@@ -25,55 +28,67 @@ type HFResponse struct {
 	Choices []struct {
 		Message HFMessage `json:"message"`
 	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
 }
 
-func Summarize(text string) (string, error) {
-	apiKey := os.Getenv("OPENROUTER_API_KEY")
+var client = &http.Client{Timeout: 60 * time.Second}
 
+func Summarize(ctx context.Context, text string) (string, error) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
 	if apiKey == "" {
-		return "", fmt.Errorf("OPENROUTER_API_KEY não definida")
+		return "", fmt.Errorf("OPENROUTER_API_KEY nao definida")
 	}
 
 	reqBody := HFRequest{
-		Model: "google/gemma-3-12b-it:free",
+		Model:  "google/gemma-3-12b-it:free",
+		Stream: false,
 		Messages: []HFMessage{
-			{
-				Role:    "user",
-				Content: "Resuma o texto em tópicos claros:\n\n" + text,
-			},
+			{Role: "user", Content: "Resuma o texto em topicos claros:\n\n" + text},
 		},
 	}
 
-	jsonData, _ := json.Marshal(reqBody)
-
-	req, err := http.NewRequest("POST", APIURL, bytes.NewBuffer(jsonData))
+	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("serializar request: %w", err)
 	}
 
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, APIURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("criar request: %w", err)
+	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("HTTP-Referer", "https://github.com/cleziojr/diario-oficial")
-	req.Header.Set("X-Title", "Insight Diário")
+	req.Header.Set("X-Title", "Insight Diario")
 
-	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("executar request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, _ := io.ReadAll(resp.Body)
-	fmt.Println("Resposta crua:", string(bodyBytes))
-
-	var result HFResponse
-	err = json.Unmarshal(bodyBytes, &result)
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("ler resposta: %w", err)
 	}
 
-	if len(result.Choices) == 0 {
-		return "", fmt.Errorf("resposta vazia")
+	if resp.StatusCode != http.StatusOK {
+		var partial HFResponse
+		if json.Unmarshal(bodyBytes, &partial) == nil && partial.Error != nil {
+			return "", fmt.Errorf("API retornou %d: %s", resp.StatusCode, partial.Error.Message)
+		}
+		return "", fmt.Errorf("API retornou status %d", resp.StatusCode)
+	}
+
+	var result HFResponse
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		return "", fmt.Errorf("deserializar resposta: %w", err)
+	}
+
+	if len(result.Choices) == 0 || result.Choices[0].Message.Content == "" {
+		return "", fmt.Errorf("resposta vazia da API")
 	}
 
 	return result.Choices[0].Message.Content, nil

--- a/ai-service/internal/llm/llm_service.go
+++ b/ai-service/internal/llm/llm_service.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"time"
+	"ai-service/internal/prompt"
 )
 
 var APIURL = "https://openrouter.ai/api/v1/chat/completions"
@@ -45,7 +46,7 @@ func Summarize(ctx context.Context, text string) (string, error) {
 		Model:  "google/gemma-3-12b-it:free",
 		Stream: false,
 		Messages: []HFMessage{
-			{Role: "user", Content: "Resuma o texto em topicos claros:\n\n" + text},
+			{Role: "user", Content: prompt.Build(text)},
 		},
 	}
 

--- a/ai-service/internal/prompt/prompt_builder.go
+++ b/ai-service/internal/prompt/prompt_builder.go
@@ -1,1 +1,18 @@
 package prompt
+
+import "fmt"
+
+func Build(text string) string {
+	return fmt.Sprintf(`Voce e um assistente especializado em analise de Diarios Oficiais brasileiros.
+
+Analise o trecho abaixo e produza um resumo estruturado em topicos claros, destacando:
+- Atos administrativos relevantes (nomeacoes, exoneracoes, contratos, licitacoes)
+- Valores financeiros mencionados
+- Prazos e datas importantes
+- Orgaos e entidades envolvidos
+
+Seja objetivo. Nao repita o texto original.
+
+TEXTO:
+%s`, text)
+}

--- a/ai-service/tests/llm_test.go
+++ b/ai-service/tests/llm_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,43 +10,82 @@ import (
 	"ai-service/internal/llm"
 )
 
-func TestSummarize_Success(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func mockServer(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{
-			"choices": [
-				{"message": {"role": "assistant", "content": "1. Teste de resumo\n2. Mock funcionando"}}
-			]
-		}`))
+		w.WriteHeader(status)
+		w.Write([]byte(body))
 	}))
-	defer mockServer.Close()
+}
 
-	originalURL := llm.APIURL
-	llm.APIURL = mockServer.URL
-	defer func() { llm.APIURL = originalURL }()
+func TestSummarize_Success(t *testing.T) {
+	srv := mockServer(http.StatusOK, `{"choices":[{"message":{"role":"assistant","content":"1. Resumo\n2. Mock ok"}}]}`)
+	defer srv.Close()
 
+	llm.APIURL = srv.URL
 	os.Setenv("OPENROUTER_API_KEY", "chave-fake")
 	defer os.Unsetenv("OPENROUTER_API_KEY")
 
-	summary, err := llm.Summarize("Texto de exemplo")
-
+	summary, err := llm.Summarize(context.Background(), "Texto de exemplo")
 	if err != nil {
-		t.Fatalf("Não esperava erro, mas obteve: %v", err)
+		t.Fatalf("nao esperava erro: %v", err)
 	}
-
-	expected := "1. Teste de resumo\n2. Mock funcionando"
-	if summary != expected {
-		t.Errorf("Esperava o resumo %q, obteve %q", expected, summary)
+	if summary != "1. Resumo\n2. Mock ok" {
+		t.Errorf("resumo inesperado: %q", summary)
 	}
 }
 
 func TestSummarize_MissingAPIKey(t *testing.T) {
 	os.Unsetenv("OPENROUTER_API_KEY")
-
-	_, err := llm.Summarize("Texto")
-
+	_, err := llm.Summarize(context.Background(), "Texto")
 	if err == nil {
-		t.Error("Esperava um erro por falta de API KEY, mas a função retornou sucesso")
+		t.Error("esperava erro por falta de API key")
+	}
+}
+
+func TestSummarize_APIError(t *testing.T) {
+	srv := mockServer(http.StatusInternalServerError, `{"error":{"message":"rate limit"}}`)
+	defer srv.Close()
+
+	llm.APIURL = srv.URL
+	os.Setenv("OPENROUTER_API_KEY", "chave-fake")
+	defer os.Unsetenv("OPENROUTER_API_KEY")
+
+	_, err := llm.Summarize(context.Background(), "Texto")
+	if err == nil {
+		t.Error("esperava erro para status 500")
+	}
+}
+
+func TestSummarize_EmptyChoices(t *testing.T) {
+	srv := mockServer(http.StatusOK, `{"choices":[]}`)
+	defer srv.Close()
+
+	llm.APIURL = srv.URL
+	os.Setenv("OPENROUTER_API_KEY", "chave-fake")
+	defer os.Unsetenv("OPENROUTER_API_KEY")
+
+	_, err := llm.Summarize(context.Background(), "Texto")
+	if err == nil {
+		t.Error("esperava erro para choices vazio")
+	}
+}
+
+func TestSummarize_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	llm.APIURL = srv.URL
+	os.Setenv("OPENROUTER_API_KEY", "chave-fake")
+	defer os.Unsetenv("OPENROUTER_API_KEY")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := llm.Summarize(ctx, "Texto")
+	if err == nil {
+		t.Error("esperava erro de contexto cancelado")
 	}
 }


### PR DESCRIPTION
O módulo de IA do projeto diario-oficial foi refatorado para corrigir vulnerabilidades críticas de produção: o http.Client passou a ter timeout de 60 segundos, eliminando o risco de goroutines presas indefinidamente; erros de serialização e leitura de resposta, antes descartados silenciosamente, agora são propagados corretamente; um limite de 4MB foi imposto na leitura do body; e acessos a índices sem validação prévia foram protegidos. 

Complementarmente, foi adicionado retry com backoff exponencial no ponto de entrada, o prompt foi centralizado em um pacote dedicado e o contexto passou a ser propagado em toda a cadeia de chamadas, tornando o serviço cancelável e preparado para integração HTTP com o backend.